### PR TITLE
chore(skills): add shell scripting

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -200,6 +200,8 @@ params:
         icon: "fab fa-node"
       - name: "Linux"
         icon: "fab fa-linux"
+      - name: "Shell Scripting"
+        icon: "fas fa-terminal"
     ml:
       - name: "Tailwind\nCSS"
         icon: "/images/tailwind.svg"


### PR DESCRIPTION
This pull request includes a small change to the `exampleSite/config.yaml` file. The change adds a new entry for "Shell Scripting" with its corresponding icon to the `params:` section.

Changes to `params:`:

* [`exampleSite/config.yaml`](diffhunk://#diff-1926bed36200257684beefb9e338d8dc0679b7226f1cb4290fb677139853dfb9R203-R204): Added "Shell Scripting" with icon `fas fa-terminal`.