### PR TITLE
fix(skills): style change to skill

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -201,7 +201,7 @@ params:
       - name: "Linux"
         icon: "fab fa-linux"
       - name: "Shell Scripting"
-        icon: "fas fa-terminal"
+        icon: "fat fa-terminal"
     ml:
       - name: "Tailwind\nCSS"
         icon: "/images/tailwind.svg"


### PR DESCRIPTION
This pull request includes a small change to the `exampleSite/config.yaml` file. The change updates the icon class for the "Shell Scripting" entry.

* [`exampleSite/config.yaml`](diffhunk://#diff-1926bed36200257684beefb9e338d8dc0679b7226f1cb4290fb677139853dfb9L204-R204): Changed the icon class for "Shell Scripting" from `fas fa-terminal` to `fat fa-terminal`.