### PR TITLE
chore(resume): link to new resume

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -132,7 +132,7 @@ params:
     button:
       enable: true
       name: "Resume"
-      url: "https://1drv.ms/w/s!AlwQ8SHBTye_h1bJIEW4_CMrIpFl?e=EPKvU9"
+      url: "https://drive.google.com/file/d/1_iffxAdiC3LP4J89VsUYr1q4dcgCc2AN/view?usp=sharing"
       download: true
       newPage: true
     socialLinks:


### PR DESCRIPTION
This pull request includes a small change to the `exampleSite/config.yaml` file. The change updates the URL for the resume button to a new Google Drive link.

* [`exampleSite/config.yaml`](diffhunk://#diff-1926bed36200257684beefb9e338d8dc0679b7226f1cb4290fb677139853dfb9L135-R135): Updated the URL for the resume button to "https://drive.google.com/file/d/1_iffxAdiC3LP4J89VsUYr1q4dcgCc2AN/view?usp=sharing".